### PR TITLE
[DEMO]: Add voxynth to "training" extras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ numpy
 matplotlib
 neurite
 scikit-image
-voxynth @ git+https://github.com/dalcalab/voxynth.git
 pylot @ git+https://github.com/JJGO/pylot.git
 wandb

--- a/requirements_training.txt
+++ b/requirements_training.txt
@@ -1,0 +1,1 @@
+voxynth @ git+https://github.com/dalcalab/voxynth.git

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,16 @@ from setuptools import find_packages, setup
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
+with open("requirements_training.txt") as f:
+    requirements_training = f.read().splitlines()
+
 setup(
     name="scribbleprompt",
     version="0.1.0",
     python_requires=">=3.9",
     packages=find_packages(exclude="notebooks"),
     install_requires=requirements,
+    extras_require={
+        "training": requirements_training,
+    }
 )


### PR DESCRIPTION
Hi, this is a demo showcasing how to add training-only dependencies into a separated extra so that they are not install if scribbleprompt is installed for inference only.

By running :
`pip install "scribbleprompt @ git+https://github.com/halleewong/ScribblePrompt.git"`, voxynth will not be installed :
![image](https://github.com/user-attachments/assets/994062bf-0a54-4279-bda5-e5103320d3e6)

And running:
`pip install "scribbleprompt[training] @ git+https://github.com/halleewong/ScribblePrompt.git"` will result in voxynth being installed correctly:
![image](https://github.com/user-attachments/assets/1840f860-f691-4b25-b377-4c65fc1cfcf5)


